### PR TITLE
compatibility with Thumbor 7.3.0., version bumbed to 0.3.0

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,4 +9,4 @@ name = "pypi"
 pylint = "<2.0.0"
 
 [requires]
-python_version = "2.7"
+python_version = "3"

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     install_requires=[
         'python-dateutil',
         'six',
-        'thumbor>=6.0.0,<7',
+        'thumbor>=7.2.0',
     ],
     extras_require={
         "tests": [

--- a/tc_multidir/_version.py
+++ b/tc_multidir/_version.py
@@ -2,4 +2,4 @@
 This module defines the package version for use in __init__.py and
 setup.py.
 """
-__version__ = '0.2.8'
+__version__ = '0.3.0'

--- a/tc_multidir/loader.py
+++ b/tc_multidir/loader.py
@@ -7,13 +7,10 @@ from os.path import join, exists, abspath
 
 from six.moves.urllib.parse import unquote
 
-from tornado.concurrent import return_future
-
 from thumbor.loaders import LoaderResult
 from thumbor.utils import logger
 
-@return_future
-def load(context, path, callback):
+async def load(context, path):
     result = LoaderResult()
 
     for idx, next_dir in enumerate(context.config.TC_MULTIDIR_PATHS):
@@ -42,8 +39,7 @@ def load(context, path, callback):
                     result.metadata.update(
                         size=stats.st_size,
                         updated_at=datetime.utcfromtimestamp(stats.st_mtime))
-                callback(result)
-                return
+                return result
 
         logger.debug('TC_MULTIDIR: File {0} not found in {1}'.format(path, next_dir))
         # else loop and try next directory
@@ -54,4 +50,4 @@ def load(context, path, callback):
     # no file found
     result.error = LoaderResult.ERROR_NOT_FOUND
     result.successful = False
-    callback(result)
+    return result


### PR DESCRIPTION
Hi @benneic,

I am not a regular python dev but with these changes I managed to make the thumbor_multidir plugin work with current Thumbor version.

I don't have pipenv/pyenv so I just built it with python3 setup.py sdist bdist_wheel and then pip install [result]

We have it in production already, everything works smoothly. Thanks for your work!

All the best,
Lubor